### PR TITLE
이전글, 다음글 보기 추가 (#11)

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+
+export const createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions;
+  const postTemplate = path.resolve(`src/templates/post.tsx`);
+  const result = (await graphql(`
+    {
+      allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
+        edges {
+          node {
+            frontmatter {
+              slug
+            }
+            id
+          }
+        }
+      }
+    }
+  `)) as {
+    data: {
+      allMarkdownRemark: {
+        edges: {
+          node: {
+            frontmatter: {
+              slug: string;
+            };
+            id: string;
+          };
+        }[];
+      };
+    };
+  };
+
+  const edges = result.data.allMarkdownRemark.edges;
+
+  for (let i = 0; i < edges.length; i++) {
+    const prev = i > 0 ? edges[i - 1] : undefined;
+    const next = i < edges.length - 1 ? edges[i + 1] : undefined;
+
+    createPage({
+      path: `post/${edges[i].node.frontmatter.slug}`,
+      component: postTemplate,
+      context: {
+        id: edges[i].node.id,
+        prev: prev?.node.id || '',
+        next: next?.node.id || '',
+      },
+    });
+  }
+
+  result.data.allMarkdownRemark.edges.forEach((edge) => {});
+};

--- a/src/components/post/PostNavigation/PostNavigation.css.ts
+++ b/src/components/post/PostNavigation/PostNavigation.css.ts
@@ -1,0 +1,94 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import colorPalette from '@/styles/colorPalette';
+
+export const container = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+
+    padding: '1rem',
+    borderRadius: '0.5rem',
+    backgroundColor: colorPalette.blueGrey[50],
+
+    transition: 'filter 0.2s ease',
+
+    userSelect: 'none',
+
+    ':hover': {
+      filter: 'contrast(90%)',
+    },
+  },
+
+  variants: {
+    direction: {
+      prev: {
+        flexDirection: 'row-reverse',
+
+        textAlign: 'left',
+      },
+
+      next: {
+        flexDirection: 'row',
+
+        textAlign: 'right',
+      },
+    },
+  },
+});
+
+export const textContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  flex: '1 1 auto',
+  overflow: 'hidden',
+});
+
+export const header = style({
+  color: colorPalette.blueGrey[800],
+  fontSize: '0.875rem',
+  fontWeight: '600',
+});
+
+export const title = style({
+  overflow: 'hidden',
+
+  color: colorPalette.blueGrey[900],
+  fontSize: '1rem',
+  fontWeight: '400',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const icon = recipe({
+  base: {
+    flex: '0 0 auto',
+
+    width: '1.25rem',
+
+    transition: 'transform 0.2s ease',
+  },
+
+  variants: {
+    direction: {
+      prev: {
+        selectors: {
+          [`${container()}:hover > &`]: {
+            transform: 'translateX(-0.25rem)',
+          },
+        },
+      },
+
+      next: {
+        selectors: {
+          [`${container()}:hover > &`]: {
+            transform: 'translateX(0.25rem)',
+          },
+        },
+      },
+    },
+  },
+});

--- a/src/components/post/PostNavigation/index.tsx
+++ b/src/components/post/PostNavigation/index.tsx
@@ -1,5 +1,26 @@
-const PostNavigation = () => {
-  return <div>asdsad</div>;
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid';
+import { Link } from 'gatsby';
+
+import * as s from './PostNavigation.css';
+
+interface PostNavigationProps {
+  slug: string;
+  direction: 'prev' | 'next';
+  title: string;
+}
+
+const PostNavigation = ({ slug, direction, title }: PostNavigationProps) => {
+  return (
+    <Link to={`/post/${slug}`}>
+      <div className={s.container({ direction })}>
+        <div className={s.textContainer}>
+          <span className={s.header}>{direction === 'next' ? '다음글' : '이전글'}</span>
+          <div className={s.title}>{title}</div>
+        </div>
+        <div className={s.icon({ direction })}>{direction === 'next' ? <ChevronRightIcon /> : <ChevronLeftIcon />}</div>
+      </div>
+    </Link>
+  );
 };
 
 export default PostNavigation;

--- a/src/components/post/RecentPostList/index.tsx
+++ b/src/components/post/RecentPostList/index.tsx
@@ -10,7 +10,6 @@ interface RecentPostListQuery {
     edges: {
       node: {
         id: string;
-        fileAbsolutePath: string;
         excerpt: string;
         frontmatter: {
           date: string;
@@ -35,10 +34,9 @@ const RecentPostList = () => {
         edges {
           node {
             id
-            fileAbsolutePath
             excerpt(pruneLength: 100)
             frontmatter {
-              date(formatString: "MMMM DD, YYYY")
+              date
               title
               slug
               tags

--- a/src/styles/page/post.css.ts
+++ b/src/styles/page/post.css.ts
@@ -2,6 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 import colorPalette from '@/styles/colorPalette';
 import theme from '@/styles/theme.css';
+import { breakpoints } from '@/styles/tokens';
 
 export const container = style({
   maxWidth: '50rem',
@@ -40,4 +41,24 @@ export const toc = style({
       display: 'none',
     },
   },
+});
+
+export const navigation = style({
+  display: 'grid',
+  gap: '2rem',
+  gridTemplateColumns: '1fr 1fr',
+
+  marginTop: '2rem',
+  padding: '0 1rem',
+
+  '@media': {
+    [`screen and (max-width: ${breakpoints.xs})`]: {
+      gap: '1rem',
+      gridTemplateColumns: '1fr',
+    },
+  },
+});
+
+export const navigationItem = style({
+  overflow: 'hidden',
 });

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { formatDate } from '@/utils/time';
 
 import Layout from '@/components/layout/Layout';
+import PostNavigation from '@/components/post/PostNavigation';
 import TagList from '@/components/post/TagList';
 import ToC from '@/components/post/ToC';
 
@@ -21,6 +22,18 @@ interface PostPageQuery {
     };
     html: string;
   };
+  prev: {
+    frontmatter: {
+      slug: string;
+      title: string;
+    };
+  } | null;
+  next: {
+    frontmatter: {
+      slug: string;
+      title: string;
+    };
+  } | null;
 }
 
 const PostPage = ({ data }: { data: PostPageQuery }) => {
@@ -40,6 +53,18 @@ const PostPage = ({ data }: { data: PostPageQuery }) => {
             <ToC contentRef={contentRef} />
           </div>
         </div>
+        <div className={s.navigation}>
+          <div className={s.navigationItem}>
+            {data.prev && (
+              <PostNavigation direction="prev" slug={data.prev.frontmatter.slug} title={data.prev.frontmatter.title} />
+            )}
+          </div>
+          <div className={s.navigationItem}>
+            {data.next && (
+              <PostNavigation direction="next" slug={data.next.frontmatter.slug} title={data.next.frontmatter.title} />
+            )}
+          </div>
+        </div>
       </div>
     </Layout>
   );
@@ -53,7 +78,7 @@ export const Head: HeadFC = () => (
 );
 
 export const query = graphql`
-  query ($id: String) {
+  query ($id: String, $prev: String, $next: String) {
     markdownRemark(id: { eq: $id }) {
       frontmatter {
         title
@@ -62,6 +87,18 @@ export const query = graphql`
         date
       }
       html
+    }
+    prev: markdownRemark(id: { eq: $prev }) {
+      frontmatter {
+        slug
+        title
+      }
+    }
+    next: markdownRemark(id: { eq: $next }) {
+      frontmatter {
+        slug
+        title
+      }
     }
   }
 `;


### PR DESCRIPTION
- gatsby node api로 정적 페이지 생성하도록 변경함
- 이전글, 다음글 보기 기능 추가

파일명으로 정적페이지 생성하면 (https://www.gatsbyjs.com/docs/tutorial/getting-started/part-6/#task-create-blog-post-page-template)
해당 기능 구현에 어려움이 있어 gatsby node api로 변경함

Issue
- #11 